### PR TITLE
Speed Up Sonar Simulation

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -11,8 +11,7 @@
   <depend package="opencv" />
   <depend package="gui/vizkit3d_normal_depth_map" /> 
   <depend package="gui/vizkit3d_world" />
- 
-  
+  <tags>needs_ops</tags>
   <!-- osg dependencies -->
   <rosdep name="osg" />
 </package>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,3 +2,6 @@ rock_library(gpu_sonar_simulation
     SOURCES Sonar.cpp Utils.cpp
     HEADERS Sonar.hpp Utils.hpp
     DEPS_PKGCONFIG base-types openscenegraph opencv)
+
+rock_executable(main main.cpp
+    DEPS gpu_sonar_simulation)

--- a/src/Sonar.cpp
+++ b/src/Sonar.cpp
@@ -6,21 +6,26 @@ using namespace cv;
 void Sonar::decodeShader(const cv::Mat& cv_image, std::vector<float>& bins) {
     bins.assign(beam_count * bin_count, 0.0);
 
-    double const beam_size = beam_width.getRad() / beam_count;
-    double const half_fovx = beam_width.getRad() / 2;
-    double const half_width = static_cast<double>(cv_image.cols) / 2;
-    double const angle2x = half_width / tan(half_fovx);
+    if (beam_cols.empty()) {
+        double beam_size = beam_width.getRad() / beam_count;
+        double half_fovx = beam_width.getRad() / 2;
+        double half_width = static_cast<double>(cv_image.cols) / 2;
+        double angle2x = half_width / tan(half_fovx);
 
-    // associates shader columns with their respective beam
+        // associates shader columns with their respective beam
+        for (unsigned int beam_idx = 0; beam_idx < beam_count; ++beam_idx) {
+            int min_col = round(half_width + tan(-half_fovx + beam_idx * beam_size) * angle2x);
+            int max_col = round(half_width + tan(-half_fovx + (beam_idx + 1) * beam_size) * angle2x);
+            beam_cols.push_back(min_col);
+            beam_cols.push_back(max_col);
+        }
+    }
+
     for (unsigned int beam_idx = 0; beam_idx < beam_count; ++beam_idx) {
-        int min_col = round(half_width + tan(-half_fovx + beam_idx * beam_size) * angle2x);
-        int max_col = round(half_width + tan(-half_fovx + (beam_idx + 1) * beam_size) * angle2x);
-        cv::Mat cv_roi = cv_image.colRange(min_col, max_col);
-
+        cv::Mat cv_roi = cv_image.colRange(beam_cols[beam_idx * 2], beam_cols[beam_idx * 2 + 1]);
         std::vector<float> raw_intensity;
         convertShader(cv_roi, raw_intensity);
-        for (unsigned int bin_idx = 0; bin_idx < bin_count; bin_idx++)
-            bins[bin_count * beam_idx + bin_idx] = raw_intensity[bin_idx];
+        memcpy(&bins[bin_count * beam_idx], &raw_intensity[0], bin_count * sizeof(float));
     }
 }
 

--- a/src/Sonar.cpp
+++ b/src/Sonar.cpp
@@ -85,14 +85,9 @@ void Sonar::rescaleIntensity(const std::vector<float>& src, std::vector<float>& 
 }
 
 float Sonar::sigmoid(float x) {
-    float l = 1, k = 18, x0 = 0.666666667;
-    float exp_value;
-
-    // Exponential calculation
-    exp_value = exp((double) (-k * (x - x0)));
-
-    // Final sigmoid value
-    return (l / (1 + exp_value));
+    float beta = 18, x0 = 0.666666667;
+    float t = (x - x0) * beta;
+    return (0.5 * tanh(0.5 * t) + 0.5);
 }
 
 float Sonar::getSamplingInterval(float range) {

--- a/src/Sonar.hpp
+++ b/src/Sonar.hpp
@@ -82,7 +82,14 @@ private:
     *  @param cv_image: the shader image (normal and depth informations) in float
     *  @param bins: the output simulated sonar data (one beam) in float
     */
-    void convertShader(cv::Mat& cv_image, float* bins);
+    void convertShader(cv::Mat& cv_image, std::vector<float>& bins);
+
+    /**
+    *  Rescale the sonar intensity data applying a linear transformation.
+    *  @param src: the raw bins intensity values in float
+    *  @param dst: the rescaled bins intensity values in float
+    */
+    void linearInterpolation(const std::vector<float>& src, std::vector<float>& dst);
 
     /**
     *  Accept the input value x then returns it's sigmoid value in float.

--- a/src/Sonar.hpp
+++ b/src/Sonar.hpp
@@ -31,12 +31,16 @@ public:
     /** The speed of sound in the water in m/s */
     float speed_of_sound;
 
+    /** Correlation between shader columns with their respective beams */
+    std::vector<int> beam_cols;
+
     Sonar()
 	    : bin_count(500)
 	    , beam_count(0)
 	    , beam_width(base::Angle::fromRad(0.0))
 	    , beam_height(base::Angle::fromRad(0.0))
 	    , speed_of_sound(base::samples::Sonar::getSpeedOfSoundInWater())
+	    , beam_cols()
     {}
 
     Sonar(uint32_t bin_count, uint32_t beam_count, base::Angle beam_width, base::Angle beam_height)
@@ -45,6 +49,7 @@ public:
 	    , beam_width(beam_width)
 	    , beam_height(beam_height)
 	    , speed_of_sound(base::samples::Sonar::getSpeedOfSoundInWater())
+	    , beam_cols()
     {}
 
     /**

--- a/src/Sonar.hpp
+++ b/src/Sonar.hpp
@@ -82,7 +82,7 @@ private:
     *  @param cv_image: the shader image (normal and depth informations) in float
     *  @param bins: the output simulated sonar data (one beam) in float
     */
-    void convertShader(const cv::Mat& cv_image, std::vector<float>& bins);
+    void convertShader(cv::Mat& cv_image, float* bins);
 
     /**
     *  Accept the input value x then returns it's sigmoid value in float.

--- a/src/Sonar.hpp
+++ b/src/Sonar.hpp
@@ -85,15 +85,6 @@ private:
     void convertShader(const cv::Mat& cv_image, std::vector<float>& bins);
 
     /**
-    *  The shader has a precision float limitation (1/256 = 0.00390625). To avoid "black
-    *  "  wholes" in the final sonar image if number of bins be more than 256, this function
-    *  rescale the sonar intensity data applying a linear transformation.
-    *  @param src: the raw bins intensity values in float
-    *  @param dst: the rescaled bins intensity values in float
-    */
-    void rescaleIntensity(const std::vector<float>& src, std::vector<float>& dst);
-
-    /**
     *  Accept the input value x then returns it's sigmoid value in float.
     *  @param x: the input value in float
     *  @return the sigmoid value in float

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <numeric>
 
 // Rock includes
 #include <gpu_sonar_simulation/Sonar.hpp>
@@ -28,31 +29,49 @@ cv::Mat createRandomImage(int rows, int cols) {
 int main(int argc, char* argv[])
 {
     /* generate a random shader image */
-    uint width = 5144;
+    uint width = 3352;
     base::Angle beam_width = base::Angle::fromDeg(120.0);
     base::Angle beam_height = base::Angle::fromDeg(20.0);
     uint height = width * tan(beam_height.rad * 0.5) / tan(beam_width.rad * 0.5);
     cv::Mat cv_shader = createRandomImage(height, width);
 
-    base::Time ts0 = base::Time::now();
-
     /* initialize Sonar Simulation */
-    uint32_t bin_count = 500;
+    uint32_t bin_count = 1000;
     uint32_t beam_count = 256;
     Sonar sonar_sim(bin_count, beam_count, beam_width, beam_height);
 
-    /* simulate sonar image */
-    std::vector<float> bins;
-    sonar_sim.decodeShader(cv_shader, bins);
+    /* process 200 times */
+    std::vector<double> timestamp;
+    for (size_t i = 0; i < 200; i++) {
+        base::Time ts0 = base::Time::now();
 
-    /* apply additional gain */
-    float gain = 0.5;
-    sonar_sim.applyAdditionalGain(bins, gain);
+        /* simulate sonar image */
+        std::vector<float> bins;
+        sonar_sim.decodeShader(cv_shader, bins);
 
-    /* encapsulate in rock's sonar structure */
-    base::samples::Sonar sonar = sonar_sim.simulateSonar(bins, 50);
+        /* apply additional gain */
+        float gain = 0.5;
+        sonar_sim.applyAdditionalGain(bins, gain);
 
-    std::cout << "Time: " << (base::Time::now() - ts0).toSeconds() << std::endl;
+        /* encapsulate in rock's sonar structure */
+        float range = 50.0;
+        base::samples::Sonar sonar = sonar_sim.simulateSonar(bins, range);
+
+        /* accumulate timestamps */
+        timestamp.push_back((base::Time::now() - ts0).toSeconds());
+    }
+
+    /* Performance results */
+    double sum = std::accumulate(timestamp.begin(), timestamp.end(), 0.0);
+    double mean = sum / timestamp.size();
+
+    double accum = 0.0;
+    for (size_t i = 0; i < timestamp.size(); i++)
+        accum += (timestamp[i] - mean) * (timestamp[i] - mean);
+    double stddev = sqrt(accum / (timestamp.size() - 1));
+
+    std::cout << "=== MEAN  : " << mean << std::endl;
+    std::cout << "=== STDDEV: " << stddev << std::endl;
 
     return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,58 @@
+#include <iostream>
+
+// Rock includes
+#include <gpu_sonar_simulation/Sonar.hpp>
+#include <gpu_sonar_simulation/Utils.hpp>
+
+// OpenCV includes
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+
+using namespace gpu_sonar_simulation;
+using namespace cv;
+
+#define myrand ((float)(random())/(float)(RAND_MAX) )
+
+// create a depth and normal matrixes to test
+cv::Mat createRandomImage(int rows, int cols) {
+    cv::Mat raw_image = cv::Mat::zeros(rows, cols, CV_32FC3);
+
+    for (int k = 0; k < raw_image.channels() - 1; k++)
+        for (int i = 0; i < rows; i++)
+            for (int j = 0; j < cols; j++)
+                raw_image.at<Vec3f>(i, j)[k] = myrand;
+
+    return raw_image;
+}
+
+int main(int argc, char* argv[])
+{
+    /* generate a random shader image */
+    uint width = 5144;
+    base::Angle beam_width = base::Angle::fromDeg(120.0);
+    base::Angle beam_height = base::Angle::fromDeg(20.0);
+    uint height = width * tan(beam_height.rad * 0.5) / tan(beam_width.rad * 0.5);
+    cv::Mat cv_shader = createRandomImage(height, width);
+
+    base::Time ts0 = base::Time::now();
+
+    /* initialize Sonar Simulation */
+    uint32_t bin_count = 500;
+    uint32_t beam_count = 256;
+    Sonar sonar_sim(bin_count, beam_count, beam_width, beam_height);
+
+    /* simulate sonar image */
+    std::vector<float> bins;
+    sonar_sim.decodeShader(cv_shader, bins);
+
+    /* apply additional gain */
+    float gain = 0.5;
+    sonar_sim.applyAdditionalGain(bins, gain);
+
+    /* encapsulate in rock's sonar structure */
+    base::samples::Sonar sonar = sonar_sim.simulateSonar(bins, 50);
+
+    std::cout << "Time: " << (base::Time::now() - ts0).toSeconds() << std::endl;
+
+    return 0;
+}


### PR DESCRIPTION
Now the sonar simulation works with a shader image in floating-point numbers (instead of 8-bit):
- Turned on compiler optimizations on cmake
- Refactored and improved simulation methods using valgrind - convertShader() and decodeShader()  
- Use of faster sigmoid function
- Removed 8-bit interpolation (it is no longer necessary)