### PR TITLE
Embed the simulation functionalities from component to the library

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -9,7 +9,8 @@
   <depend package="base/cmake" />
   <depend package="base/types" />
   <depend package="opencv" />
-  <test_depend package="simulation/normal_depth_map" />
+  <depend package="perception/frame_helper" />
+  <depend package="simulation/normal_depth_map" />
   <tags>needs_ops</tags>
   <!-- osg dependencies -->
   <rosdep name="osg" />

--- a/manifest.xml
+++ b/manifest.xml
@@ -9,6 +9,7 @@
   <depend package="base/cmake" />
   <depend package="base/types" />
   <depend package="opencv" />
+  <test_depend package="simulation/normal_depth_map" />
   <tags>needs_ops</tags>
   <!-- osg dependencies -->
   <rosdep name="osg" />

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 rock_library(gpu_sonar_simulation
     SOURCES Sonar.cpp Utils.cpp SonarSimulation.cpp
     HEADERS Sonar.hpp Utils.hpp SonarSimulation.hpp
-    DEPS_PKGCONFIG base-types openscenegraph opencv vizkit3d_normal_depth_map
+    DEPS_PKGCONFIG base-types openscenegraph opencv normal_depth_map
     frame_helper)
 
 rock_executable(main main.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,8 @@
 rock_library(gpu_sonar_simulation
-    SOURCES Sonar.cpp Utils.cpp
-    HEADERS Sonar.hpp Utils.hpp
-    DEPS_PKGCONFIG base-types openscenegraph opencv)
+    SOURCES Sonar.cpp Utils.cpp SonarSimulation.cpp
+    HEADERS Sonar.hpp Utils.hpp SonarSimulation.hpp
+    DEPS_PKGCONFIG base-types openscenegraph opencv vizkit3d_normal_depth_map
+    frame_helper)
 
 rock_executable(main main.cpp
     DEPS gpu_sonar_simulation)

--- a/src/SonarSimulation.cpp
+++ b/src/SonarSimulation.cpp
@@ -7,7 +7,8 @@ SonarSimulation::SonarSimulation(float range, float gain, uint32_t bin_count,
         uint32_t beam_count, base::Angle beam_width, base::Angle beam_height, 
         uint value, bool isHeight, osg::ref_ptr<osg::Group> root):
     sonar(bin_count, beam_count, beam_width, beam_height),
-    gain(gain)
+    gain(gain),
+    range(range)
 {
     double const half_fovx = sonar.beam_width.getRad() / 2;
     double const half_fovy = sonar.beam_height.getRad() / 2;
@@ -67,7 +68,6 @@ base::samples::Sonar SonarSimulation::simulateSonarData(const Eigen::Affine3d& s
     processShader(osg_image, bins);
 
     // simulate sonar data
-    float range = 50.0f; 
     base::samples::Sonar sim_sonar_data = sonar.simulateSonar(bins, range);
 
     return sim_sonar_data;
@@ -130,9 +130,10 @@ void SonarSimulation::setGain(float gain_value)
     gain = gain_value;
 }
 
-void SonarSimulation::setRange(float range)
+void SonarSimulation::setRange(float range_value)
 {
-    normal_depth_map.setMaxRange(range);
+    normal_depth_map.setMaxRange(range_value);
+    range = range_value;
 }    
 
 

--- a/src/SonarSimulation.cpp
+++ b/src/SonarSimulation.cpp
@@ -41,12 +41,6 @@ void SonarSimulation::processShader(osg::ref_ptr<osg::Image>& osg_image, std::ve
  
     // apply the additional gain
     sonar.applyAdditionalGain(bins, gain);
-    // display shader image
-    //std::auto_ptr<base::samples::frame::Frame> frame(new base::samples::frame::Frame());
-    //getLastFrame(*frame.get());
-    
-    //frame->time = base::Time::now();
-    //_shader_viewer.write(RTT::extras::ReadOnlyPointer<Frame>(frame.release()));
 
 }
 
@@ -87,9 +81,6 @@ void SonarSimulation::updateSonarPose(const Eigen::Affine3d pose)
 
     // transformation matrixes multiplication
     osg::Matrixd matrix(pose.data());
-    //matrix.setTrans(osg::Vec3(pose.translation()));
-    //matrix.setRotate(osg::Quat(pose.orientation.x(), pose.orientation.y(), 
-    //pose.orientation.z(), pose.orientation.w()));
     matrix.invert(matrix);
 
     // correct coordinate system and apply geometric transformations

--- a/src/SonarSimulation.cpp
+++ b/src/SonarSimulation.cpp
@@ -1,0 +1,147 @@
+#include "SonarSimulation.hpp"
+#include <gpu_sonar_simulation/Utils.hpp>
+#include <memory>
+using namespace gpu_sonar_simulation;
+
+SonarSimulation::SonarSimulation(float range, float gain, uint32_t bin_count, 
+        uint32_t beam_count, base::Angle beam_width, base::Angle beam_height, 
+        uint value, bool isHeight, osg::ref_ptr<osg::Group> root):
+    sonar(bin_count, beam_count, beam_width, beam_height),
+    gain(gain)
+{
+    double const half_fovx = sonar.beam_width.getRad() / 2;
+    double const half_fovy = sonar.beam_height.getRad() / 2;
+
+    // initialize shader (NormalDepthMap and ImageViewerCaptureTool)
+    normal_depth_map = vizkit3d_normal_depth_map::NormalDepthMap(range, half_fovx, half_fovy);
+    capture_tool = vizkit3d_normal_depth_map::ImageViewerCaptureTool(sonar.beam_height.getRad(), sonar.beam_width.getRad(), value, isHeight);
+    capture_tool.setBackgroundColor(osg::Vec4d(0.0, 0.0, 0.0, 1.0));
+    normal_depth_map.addNodeChild(root);
+}
+
+SonarSimulation::~SonarSimulation()
+{}
+
+void SonarSimulation::processShader(osg::ref_ptr<osg::Image>& osg_image, std::vector<float>& bins) {
+    // receives shader image in opencv format
+    cv::Mat cv_image, cv_depth;
+    gpu_sonar_simulation::convertOSG2CV(osg_image, cv_image);
+    osg::ref_ptr<osg::Image> osg_depth = capture_tool.getDepthBuffer();
+    gpu_sonar_simulation::convertOSG2CV(osg_depth, cv_depth);
+
+    // replace depth matrix
+    std::vector<cv::Mat> channels;
+    cv::split(cv_image, channels);
+    channels[1] = cv_depth;
+    cv::merge(channels, cv_image);
+
+    // decode shader informations to sonar data
+    sonar.decodeShader(cv_image, bins);
+    last_cv_image = cv_image;
+ 
+    // apply the additional gain
+    sonar.applyAdditionalGain(bins, gain);
+    // display shader image
+    //std::auto_ptr<base::samples::frame::Frame> frame(new base::samples::frame::Frame());
+    //getLastFrame(*frame.get());
+    
+    //frame->time = base::Time::now();
+    //_shader_viewer.write(RTT::extras::ReadOnlyPointer<Frame>(frame.release()));
+
+}
+
+base::samples::frame::Frame SonarSimulation::getLastFrame()
+{
+    last_cv_image.convertTo(last_cv_image, CV_8UC3, 255);
+    cv::flip(last_cv_image, last_cv_image, 0);
+    base::samples::frame::Frame frame;
+    frame_helper::FrameHelper::copyMatToFrame(last_cv_image, frame);
+    return frame;
+}
+
+
+base::samples::Sonar SonarSimulation::simulateSonarData(const Eigen::Affine3d& sonar_pose)
+{
+    // update the sonar pose in the depth map
+    updateSonarPose(sonar_pose);
+
+    // receive shader image
+    osg::ref_ptr<osg::Image> osg_image = 
+        capture_tool.grabImage(normal_depth_map.getNormalDepthMapNode());
+    // process the shader image
+    std::vector<float> bins;
+    processShader(osg_image, bins);
+
+    // simulate sonar data
+    float range = 50.0f; 
+    base::samples::Sonar sim_sonar_data = sonar.simulateSonar(bins, range);
+
+    return sim_sonar_data;
+}
+
+void SonarSimulation::updateSonarPose(const Eigen::Affine3d pose)
+{
+    // convert OSG (Z-forward) to RoCK coordinate system (X-forward)
+    osg::Matrixd rock_coordinate_matrix = osg::Matrixd::rotate( M_PI_2, osg::Vec3(0, 0, 1)) 
+        * osg::Matrixd::rotate(-M_PI_2, osg::Vec3(1, 0, 0));
+
+    // transformation matrixes multiplication
+    osg::Matrixd matrix(pose.data());
+    //matrix.setTrans(osg::Vec3(pose.translation()));
+    //matrix.setRotate(osg::Quat(pose.orientation.x(), pose.orientation.y(), 
+    //pose.orientation.z(), pose.orientation.w()));
+    matrix.invert(matrix);
+
+    // correct coordinate system and apply geometric transformations
+    osg::Matrixd m = matrix * rock_coordinate_matrix;
+
+    osg::Vec3 eye, center, up;
+    m.getLookAt(eye, center, up);
+    capture_tool.setCameraPosition(eye, center, up);
+}
+
+void SonarSimulation::setupShader(uint value, bool isHeight)
+{
+    capture_tool = vizkit3d_normal_depth_map::ImageViewerCaptureTool(sonar.beam_height.getRad(), sonar.beam_width.getRad(), value, isHeight);
+    capture_tool.setBackgroundColor(osg::Vec4d(0.0, 0.0, 0.0, 1.0));
+}
+
+void SonarSimulation::setSonarBinCount(uint32_t bin_count)
+{
+    sonar.bin_count = bin_count;
+}
+
+uint32_t SonarSimulation::getSonarBinCount()
+{
+    return sonar.bin_count;
+}
+
+void SonarSimulation::setSonarBeamCount(uint32_t beam_count)
+{
+    sonar.beam_count = beam_count;
+}
+uint32_t SonarSimulation::getSonarBeamCount()
+{
+    return sonar.beam_count;
+}
+
+void SonarSimulation::setSonarBeamWidth(base::Angle beam_width)
+{
+    sonar.beam_width = beam_width;
+}
+base::Angle SonarSimulation::getSonarBeamWidth()
+{
+    return sonar.beam_width;
+}
+
+void SonarSimulation::setGain(float gain_value)
+{
+    gain = gain_value;
+}
+
+void SonarSimulation::setRange(float range)
+{
+    normal_depth_map.setMaxRange(range);
+}    
+
+

--- a/src/SonarSimulation.hpp
+++ b/src/SonarSimulation.hpp
@@ -17,7 +17,7 @@ class SonarSimulation
 {
 public:
     SonarSimulation(float range,  float gain, uint32_t bin_count,  
-        base::Angle beam_width, base::Angle beam_height, uint value, 
+        base::Angle beam_width, base::Angle beam_height, unsigned int resolution, 
         bool isHeight, osg::ref_ptr<osg::Group> root, uint32_t beam_count = 0);
     ~SonarSimulation();
 
@@ -33,7 +33,7 @@ public:
     *  @param bins: the output simulated sonar data (all beams) in float
     */
     void processShader(osg::ref_ptr<osg::Image>& osg_image, std::vector<float>& bins);
-    void setupShader(uint value, bool isHeight);
+    void setupShader(unsigned int resolution, bool isHeight);
     
     base::samples::frame::Frame getLastFrame();
 
@@ -68,6 +68,8 @@ private:
     float range;
     cv::Mat last_cv_image;
     bool speckle_noise;
+    unsigned int resolution;
+    bool isHeight;
 
     gpu_sonar_simulation::Sonar sonar;
     normal_depth_map::NormalDepthMap normal_depth_map;

--- a/src/SonarSimulation.hpp
+++ b/src/SonarSimulation.hpp
@@ -1,0 +1,51 @@
+#ifndef __IMAGING_SONAR_SIMULATION_HPP__
+#define __IMAGING_SONAR_SIMULATION_HPP__
+
+#include <Eigen/Core>
+
+#include "Sonar.hpp"
+#include <vizkit3d_normal_depth_map/NormalDepthMap.hpp>
+#include <vizkit3d_normal_depth_map/ImageViewerCaptureTool.hpp>
+#include <frame_helper/FrameHelper.h>
+#include <base/samples/Sonar.hpp>
+#include <base/Angle.hpp>
+
+namespace gpu_sonar_simulation
+{
+
+class SonarSimulation
+{
+public:
+
+    SonarSimulation(float range,  float gain, uint32_t bin_count, uint32_t beam_count, base::Angle beam_width, base::Angle beam_height, uint value, bool isHeight, osg::ref_ptr<osg::Group> root);
+    ~SonarSimulation();
+    base::samples::Sonar simulateSonarData(const Eigen::Affine3d& sonar_pose);
+    void updateSonarPose(const Eigen::Affine3d pose); 
+    void processShader(osg::ref_ptr<osg::Image>& osg_image, std::vector<float>& bins);
+    void setupShader(uint value, bool isHeight);
+    
+    base::samples::frame::Frame getLastFrame();
+
+    void setSonarBinCount(uint32_t bin_count);
+    uint32_t getSonarBinCount();
+    
+    void setSonarBeamCount(uint32_t beam_count);
+    uint32_t getSonarBeamCount();
+    
+    void setSonarBeamWidth(base::Angle beam_width);
+    base::Angle getSonarBeamWidth();
+
+    void setRange(float range);
+    void setGain(float gain_value);
+    
+    double gain;
+    cv::Mat last_cv_image;
+
+    gpu_sonar_simulation::Sonar sonar;
+    vizkit3d_normal_depth_map::NormalDepthMap normal_depth_map;
+    vizkit3d_normal_depth_map::ImageViewerCaptureTool capture_tool;
+};
+
+}
+
+#endif

--- a/src/SonarSimulation.hpp
+++ b/src/SonarSimulation.hpp
@@ -4,8 +4,8 @@
 #include <Eigen/Core>
 
 #include "Sonar.hpp"
-#include <vizkit3d_normal_depth_map/NormalDepthMap.hpp>
-#include <vizkit3d_normal_depth_map/ImageViewerCaptureTool.hpp>
+#include <normal_depth_map/NormalDepthMap.hpp>
+#include <normal_depth_map/ImageViewerCaptureTool.hpp>
 #include <frame_helper/FrameHelper.h>
 #include <base/samples/Sonar.hpp>
 #include <base/Angle.hpp>
@@ -16,15 +16,32 @@ namespace gpu_sonar_simulation
 class SonarSimulation
 {
 public:
-
-    SonarSimulation(float range,  float gain, uint32_t bin_count, uint32_t beam_count, base::Angle beam_width, base::Angle beam_height, uint value, bool isHeight, osg::ref_ptr<osg::Group> root);
+    SonarSimulation(float range,  float gain, uint32_t bin_count,  
+        base::Angle beam_width, base::Angle beam_height, uint value, 
+        bool isHeight, osg::ref_ptr<osg::Group> root, uint32_t beam_count = 0);
     ~SonarSimulation();
+
+    /**
+     * Generate a sonar sample response of a sonar at a given pose
+     * @param pose: pose of the auv]
+    */
     base::samples::Sonar simulateSonarData(const Eigen::Affine3d& sonar_pose);
-    void updateSonarPose(const Eigen::Affine3d pose); 
+
+    /**
+    *  Process shader image in bins intensity.
+    *  @param osg_image: the shader image (normal, depth and angle informations) in osg::Image format
+    *  @param bins: the output simulated sonar data (all beams) in float
+    */
     void processShader(osg::ref_ptr<osg::Image>& osg_image, std::vector<float>& bins);
     void setupShader(uint value, bool isHeight);
     
     base::samples::frame::Frame getLastFrame();
+
+    void setAttenuationCoefficient( const double frequency,
+                                      const double temperature,
+                                      const double depth,
+                                      const double salinity,
+                                      const double acidity);
 
     void setSonarBinCount(uint32_t bin_count);
     uint32_t getSonarBinCount();
@@ -34,17 +51,33 @@ public:
     
     void setSonarBeamWidth(base::Angle beam_width);
     base::Angle getSonarBeamWidth();
+    
+    void setSonarBeamHeight(base::Angle beam_height);
+    base::Angle getSonarBeamHeight();
+
+    void enableSpeckleNoise(bool enable);
 
     void setRange(float range);
-    void setGain(float gain_value);
+    float getRange();
     
+    void setGain(float gain_value);
+    float getGain();
+
+private:    
     float gain;
     float range;
     cv::Mat last_cv_image;
+    bool speckle_noise;
 
     gpu_sonar_simulation::Sonar sonar;
-    vizkit3d_normal_depth_map::NormalDepthMap normal_depth_map;
-    vizkit3d_normal_depth_map::ImageViewerCaptureTool capture_tool;
+    normal_depth_map::NormalDepthMap normal_depth_map;
+    normal_depth_map::ImageViewerCaptureTool capture_tool;
+    
+    /**
+     *  Update sonar pose according to auv pose.
+     *  @param pose: pose of the auv
+    */
+    void updateSonarPose(const Eigen::Affine3d pose); 
 };
 
 }

--- a/src/SonarSimulation.hpp
+++ b/src/SonarSimulation.hpp
@@ -38,7 +38,8 @@ public:
     void setRange(float range);
     void setGain(float gain_value);
     
-    double gain;
+    float gain;
+    float range;
     cv::Mat last_cv_image;
 
     gpu_sonar_simulation::Sonar sonar;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -21,4 +21,40 @@ void convertOSG2CV(osg::ref_ptr<osg::Image>& osg_image, cv::Mat& cv_image) {
         cv_image = cv_image.mul( cv::Mat1f(cv_image < 1) / 255);
     }
 }
+    double underwaterSignalAttenuation( const double frequency,
+                                        const double temperature,
+                                        const double depth,
+                                        const double salinity,
+                                        const double acidity ) 
+    {
+    
+        double frequency2 = frequency * frequency;
+    
+        // borid acid and magnesium sulphate relaxation frequencies (in kHz)
+        double f1 = 0.78 * pow(salinity / 35, 0.5) * exp(temperature / 26);
+        double f2 = 42 * exp(temperature / 17);
+    
+        // borid acid contribution
+        double borid = 0.106 * ((f1 * frequency2) / (frequency2 + f1 * f1)) * exp((acidity - 8) / 0.56);
+    
+        // magnesium sulphate contribuion
+        double magnesium = 0.52 * (1 + temperature / 43) * (salinity / 35)
+                            * ((f2 * frequency2) / (frequency2 + f2 * f2)) * exp(-depth / 6000);
+    
+        // freshwater contribution
+        double freshwater = 0.00049 * frequency2 * exp(-(temperature / 27 + depth / 17000));
+    
+        // absorptium attenuation coefficient in dB/km
+        double attenuation = borid + magnesium + freshwater;
+    
+        // convert dB/km to dB/m
+        attenuation = attenuation / 1000.0;
+    
+        // convert dB/m to Pa/m
+        attenuation = pow(10, -attenuation / 20);
+        attenuation = -log(attenuation);
+    
+        return attenuation;
+    }
+
 }

--- a/src/Utils.hpp
+++ b/src/Utils.hpp
@@ -6,6 +6,7 @@
 
 // Openscenegraph includes
 #include <osg/Image>
+#include <cmath>
 
 namespace gpu_sonar_simulation{
     /**
@@ -14,5 +15,27 @@ namespace gpu_sonar_simulation{
     *  @param cv_image: the opencv image in cv::Mat (destination)
     */
     void convertOSG2CV(osg::ref_ptr<osg::Image>& osg_image, cv::Mat& cv_image);
+   
+    /**
+     * @brief compute Underwater Signal Attenuation coefficient
+     *
+     *  This method is based on paper "A simplified formula for viscous and
+     *  chemical absorption in sea water". The method computes the attenuation
+     *  coefficient that will be used on shader normal intensite return.
+     *
+     *  @param double frequency: sound frequency in kHz.
+     *  @param double temperature: water temperature in Celsius degrees.
+     *  @param double depth: distance from water surface in meters.
+     *  @param double salinity: amount of salt dissolved in a body of water in ppt.
+     *  @param double acidity: pH water value.
+     *
+     *  @return double coefficient attenuation value
+     */
+
+    double underwaterSignalAttenuation( const double frequency,
+                                        const double temperature,
+                                        const double depth,
+                                        const double salinity,
+                                        const double acidity);
 }
 #endif

--- a/test/test_Sonar.cpp
+++ b/test/test_Sonar.cpp
@@ -15,6 +15,7 @@
 
 // Opencv includes
 #include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc.hpp>
 
 using namespace gpu_sonar_simulation;
 using namespace normal_depth_map;


### PR DESCRIPTION
Currently I am using the sonar simulation library in my localization algortithm and I need to call the functionalities within my library to simulate individuals beams. This merge the functionalities into the gpu_sonar_simulation library and the component is responsible only to call the correct methods and to specify the difference between multibeam and MSIS.  